### PR TITLE
feat: add homepage layout with search inputs and header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "next": "15.5.4",
         "react": "19.1.0",
-        "react-dom": "19.1.0"
+        "react-dom": "19.1.0",
+        "remixicon": "^4.6.0"
       },
       "devDependencies": {
         "@eslint/eslintrc": "^3",
@@ -5107,6 +5108,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/remixicon": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/remixicon/-/remixicon-4.6.0.tgz",
+      "integrity": "sha512-bKM5odjqE1yzVxEZGJE7F79WHhNrJFIKHXR+GG+P1IWXn8AnJZhl8SbIRDJsNAvIqx4VPkNwjuHfc42tutMDpQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/resolve": {
       "version": "1.22.10",

--- a/package.json
+++ b/package.json
@@ -9,19 +9,20 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "next": "15.5.4",
     "react": "19.1.0",
     "react-dom": "19.1.0",
-    "next": "15.5.4"
+    "remixicon": "^4.6.0"
   },
   "devDependencies": {
-    "typescript": "^5",
+    "@eslint/eslintrc": "^3",
+    "@tailwindcss/postcss": "^4",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "@tailwindcss/postcss": "^4",
-    "tailwindcss": "^4",
     "eslint": "^9",
     "eslint-config-next": "15.5.4",
-    "@eslint/eslintrc": "^3"
+    "tailwindcss": "^4",
+    "typescript": "^5"
   }
 }

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,4 +1,5 @@
 @import "tailwindcss";
+@import "remixicon/fonts/remixicon.css";
 
 :root {
   --background: #ffffff;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,9 +1,9 @@
 "use client";
-import { useEffect, useState } from "react";
+import { useState, useEffect } from "react";
 
-// For client-side, we'll use the same environment variable approach
-// but with a fallback
-const API_URL = process.env.NEXT_PUBLIC_API_URL || 'https://smarterdoc-backend-1094971678787.us-central1.run.app';
+const API_URL =
+  process.env.NEXT_PUBLIC_API_URL ||
+  "https://smarterdoc-backend-1094971678787.us-central1.run.app";
 
 export default function Home() {
   const [message, setMessage] = useState("");
@@ -12,12 +12,66 @@ export default function Home() {
     fetch(`${API_URL}/hello`)
       .then((res) => res.json())
       .then((data) => setMessage(data.message))
-      .catch((err) => console.error(err));
+      .catch(console.error);
   }, []);
 
   return (
-    <main className="flex min-h-screen items-center justify-center">
-      <h1 className="text-3xl font-bold">{message || "Loading..."}</h1>
+    <main className="min-h-screen bg-gradient-to-b from-pink-100 to-purple-100 flex flex-col items-center px-4 py-16">
+      {/* Header */}
+      <header className="flex items-center justify-start w-full max-w-5xl mb-12">
+        <i className="ri-hearts-fill text-3xl text-purple-600 mr-2"></i>
+        <h1 className="text-2xl font-bold text-gray-800">Hackathon</h1>
+      </header>
+
+      {/* Title */}
+      <section className="text-center mb-10">
+        <h2 className="text-4xl font-bold text-purple-700 mb-2">
+          Smart guidance to the right doctor
+        </h2>
+        <p className="text-gray-700">
+          We connect you with the best care — clearly, fairly, and personally.
+        </p>
+      </section>
+
+      {/* Search Row 1 */}
+      <div className="flex flex-wrap justify-center gap-3 w-full max-w-4xl mb-6">
+        <input
+          type="text"
+          placeholder="Search"
+          className="flex-1 min-w-[150px] rounded-full border border-gray-300 px-4 py-2 shadow-sm focus:ring-2 focus:ring-purple-400 outline-none"
+        />
+        <input
+          type="text"
+          placeholder="Location"
+          className="flex-1 min-w-[150px] rounded-full border border-gray-300 px-4 py-2 shadow-sm focus:ring-2 focus:ring-purple-400 outline-none"
+        />
+        <input
+          type="text"
+          placeholder="Insurance"
+          className="flex-1 min-w-[150px] rounded-full border border-gray-300 px-4 py-2 shadow-sm focus:ring-2 focus:ring-purple-400 outline-none"
+        />
+        <button className="bg-purple-500 hover:bg-purple-600 text-white p-3 rounded-full shadow-md">
+          <i className="ri-search-line text-xl"></i>
+        </button>
+      </div>
+
+      {/* Search Row 2 */}
+      <div className="flex items-center w-full max-w-4xl rounded-full border border-gray-300 bg-white shadow-sm px-4 py-3">
+        <i className="ri-question-line text-gray-400 text-xl mr-3"></i>
+        <input
+          type="text"
+          placeholder="Ask a question..."
+          className="flex-1 outline-none text-gray-700"
+        />
+        <button className="bg-purple-500 hover:bg-purple-600 text-white p-3 rounded-full shadow-md">
+          <i className="ri-mic-line text-xl"></i>
+        </button>
+      </div>
+
+      {/* Backend connectivity test */}
+      <p className="text-sm text-gray-500 mt-8">
+        {message ? `Backend says: ${message}` : "Loading backend connection..."}
+      </p>
     </main>
   );
 }


### PR DESCRIPTION
## 🧩 Pull Request — Homepage Development

**Title:** `feat: homepage layout with search inputs and header`

---

### 📋 Summary
This PR implements the initial homepage layout for **SmarterDoc**, featuring:
- Header with logo and branding  
- Hero section with tagline  
- Two search rows:
  - First row: `Search`, `Location`, `Insurance` inputs + search icon  
  - Second row: `Ask a question...` input + microphone icon  
- Integrated **Remix Icons** and **Tailwind CSS 4**  
- Connected to backend `/hello` endpoint to verify FastAPI connectivity  

---

### 🖼️ Screenshots
| Desktop Preview |  
| :-------------- |  
| <img width="1240" height="622" alt="Screenshot 2025-10-07 at 2 35 45 PM" src="https://github.com/user-attachments/assets/6248642a-2489-42cb-b932-1b635ba84c9d" />|  


---

### 🧪 How to Test
1. Pull this branch:
   ```bash
   git fetch origin feat/homepage
   git checkout feat/homepage
   npm install
   npm run dev
   ```
   
2. Open http://localhost:3000/

3. Verify:

- Layout matches design (logo, heading, subheading)
- Inputs and icons appear correctly
- “Backend says: Hello Hogan” message appears from API

🔧 Technical Notes

- Environment variable used: NEXT_PUBLIC_API_URL
- API endpoint: ${NEXT_PUBLIC_API_URL}/hello
- Dependencies added:
  - remixicon for icons

✅ Checklist
- [x] UI layout matches mockup  
- [x] Responsive design verified  
- [x] Backend connectivity verified  
- [x] Code linted and formatted  
- [x] Ready for review  


