### PR TITLE
fix: google map api key missing

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -33,7 +33,9 @@ jobs:
       run: |
         docker build \
           --build-arg NEXT_PUBLIC_API_URL="https://smarterdoc-backend-${{ secrets.GCP_PROJECT_ID }}.${{ secrets.REGION }}.run.app" \
+          --build-arg NEXT_PUBLIC_GOOGLE_MAPS_API_KEY="${{ secrets.NEXT_PUBLIC_GOOGLE_MAPS_API_KEY }}" \
           -t gcr.io/${{ secrets.GCP_PROJECT_ID }}/smarterdoc-frontend .
+
 
     # Push Docker image
     - name: Push Docker Image

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,37 +4,27 @@
 FROM node:20-alpine AS builder
 
 WORKDIR /app
-
-# Copy package files first
 COPY package*.json ./
-
 RUN npm install
-
-# Copy source code
 COPY . .
 
-# Make sure NODE_ENV is production
 ENV NODE_ENV=production
 
-# Accept API URL as build argument
+# Accept API URL and Google Maps key as build arguments
 ARG NEXT_PUBLIC_API_URL
-ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ARG NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
 
-# Build the Next.js app (API URL gets baked in here)
+# Expose them as environment variables for Next.js build
+ENV NEXT_PUBLIC_API_URL=$NEXT_PUBLIC_API_URL
+ENV NEXT_PUBLIC_GOOGLE_MAPS_API_KEY=$NEXT_PUBLIC_GOOGLE_MAPS_API_KEY
+
 RUN npm run build
 
 # -----------------------
 # Run stage
 # -----------------------
 FROM node:20-alpine
-
 WORKDIR /app
-
-# Copy built app from builder
 COPY --from=builder /app ./
-
-# Expose port
 EXPOSE 3000
-
-# Run Next.js in production
 CMD ["npm", "start"]


### PR DESCRIPTION
## 🔧 Pull Request — Fix Google Maps API Key Integration

**Title:** fix: google map api key missing

---

### 📋 Summary
This PR fixes the issue where the Google Maps JavaScript API key was not being recognized in the deployed Cloud Run environment.  
The fix ensures the environment variable `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` is properly passed during the Docker build and deployment process.

---

### 🛠️ Changes
- Updated **Dockerfile** to include `ARG` and `ENV` for `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`  
- Updated **GitHub Actions** workflow (`frontend.yml`) to inject the Google Maps key during build using repository secret  
- Ensured `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY` is available at runtime in Cloud Run  
- Verified that map renders successfully in production without `ApiProjectMapError` or `NoApiKeys`  

---

### 🧪 How to Test
1. Add your Google Maps API key as a GitHub secret named `NEXT_PUBLIC_GOOGLE_MAPS_API_KEY`  
2. Push to `main` or trigger a new deployment  
3. Visit the deployed frontend URL  
4. Confirm:
   - Google Map loads correctly on `/doctor` page  
   - No console errors related to missing API key  

---

### ✅ Checklist
- [x] Google Maps API key now correctly injected during build  
- [x] Cloud Run deployment tested successfully  
- [x] No `ApiProjectMapError` or `NoApiKeys` warnings in console  
- [x] Workflow and Dockerfile validated  
- [x] Ready for review and merge  
