### PR TITLE
fix: google map size

### DIFF
--- a/src/components/DoctorMap.tsx
+++ b/src/components/DoctorMap.tsx
@@ -16,7 +16,7 @@ interface Props {
 
 const containerStyle = {
   width: "100%",
-  height: "400px",
+  height: "100%",
   borderRadius: "12px",
 };
 


### PR DESCRIPTION
### **Description**

This PR updates the Google Map container height to be fully responsive by changing the `height` property from a fixed `"400px"` value to `"100%"`. This ensures the map dynamically fits its parent container and improves layout consistency across different screen sizes.

---

### **Changes Made**

* Updated `containerStyle` in `DoctorMap` component:

  ```ts
  const containerStyle = {
    width: "100%",
    height: "100%",
    borderRadius: "12px",
  };
  ```
* Ensured `GoogleMap` uses full container space instead of a fixed pixel height.

---

### **Reason for Change**

* The previous fixed height (`400px`) limited the map’s scalability in responsive layouts.
* Changing to `100%` height allows the map to fill the parent container dynamically, improving display on both desktop and mobile views.

---

### **Testing Steps**

1. Checkout the branch:

   ```bash
   git checkout fix/google-map-size
   ```
2. Run the frontend locally:

   ```bash
   npm run dev
   ```
3. Open the page that renders the doctor map.
4. Confirm that:

   * The map height adjusts automatically to the parent container.
   * No visual cutoff or overflow occurs.
   * Markers display correctly after the change.

---

### **Reviewer Notes**

* Verify that parent containers correctly define height to allow full rendering.
* Check responsiveness in both desktop and mobile views.
* Ensure no regressions in map rendering or marker behavior.

